### PR TITLE
Add shellcheck to lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,18 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible ansible-lint
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          pip3 install yamllint ansible ansible-lint
 
       - name: Lint code.
         run: |
           yamllint .
           ansible-lint
+
+      - name: Run shellcheck.
+        run: shellcheck init.sh init_light.sh tests/uninstall-homebrew.sh
 
   integration:
     name: Integration


### PR DESCRIPTION
## Summary
- install shellcheck during lint job
- run shellcheck on init scripts

## Testing
- `pip install yamllint ansible ansible-lint` *(fails: externally-managed-environment)*
- `shellcheck init.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415441a48c832c9afd11e2e3e1a06e