### PR TITLE
Fix typos in post tasks

### DIFF
--- a/tasks/post/citrix.yml
+++ b/tasks/post/citrix.yml
@@ -4,7 +4,7 @@
   register: citrix_url
   become: false
 
-- name: Downloasd Citrix DMG
+- name: Download Citrix DMG
   get_url:
     url: "{{ citrix_url.stdout }}"
     dest: /tmp/citrix.dmg

--- a/tasks/post/various-settings.yml
+++ b/tasks/post/various-settings.yml
@@ -26,7 +26,7 @@
   shell: curl --silent "https://api.github.com/repos/kcrawford/dockutil/releases/latest" | jq -r .assets[].browser_download_url | grep pkg
   register: dockutil_dl
 
-- name: Downloasd dokutil pkg
+- name: Download dockutil pkg
   get_url:
     url: "{{ dockutil_dl.stdout }}"
     dest: /tmp/dockutil.pkg


### PR DESCRIPTION
## Summary
- fix typos in Citrix and dockutil tasks
- ensure newline at end of various-settings.yml

## Testing
- `yamllint --version` *(fails: command not found)*
- `ansible-lint --version` *(fails: command not found)*
- `ansible-playbook --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841545c2548832cbbc07085e6954e7c